### PR TITLE
update for recent versions of gdbm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gdbm-sys"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 homepage = "https://github.com/cholcombe973/gdbm-sys"
 description = "gdbm (berkeley database) FFI bindings"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,6 @@ extern "C" {
                        arg4: ::std::os::raw::c_int)
                        -> ::std::os::raw::c_int;
     pub fn gdbm_fdesc(arg1: GDBM_FILE) -> ::std::os::raw::c_int;
-    pub static mut gdbm_errno: gdbm_error;
-    pub fn gdbm_strerror(arg1: gdbm_error) -> *mut ::std::os::raw::c_char;
+    pub fn gdbm_errno_location() -> *mut gdbm_error;
+    pub fn gdbm_strerror(arg1: gdbm_error) -> *const ::std::os::raw::c_char;
 }


### PR DESCRIPTION
Recent versions of gdbm don't have a global gdbm_errno, it's a
thread-local variable. the address of that variable can be retrieved
with gdbm_errno_location(). gdbm_errno in C is #defined as
*gdbm_errno_location.

So remove the gdbm_errno export and add gdbm_errno_location.

While we're at it, gdbm_strerror() is now a const function, so update
that as well.

Update version to 0.3.